### PR TITLE
fix(sourceInfo): :bug: fix sourceInfo in SPDX

### DIFF
--- a/lib4sbom/spdx/spdx_parser.py
+++ b/lib4sbom/spdx/spdx_parser.py
@@ -399,8 +399,8 @@ class SPDXParser:
                                 spdx_package.set_checksum(
                                     checksum["algorithm"], checksum["checkumValue"]
                                 )
-                        if "sourceinfo" in d:
-                            spdx_package.set_sourceInfo(d["sourceinfo"])
+                        if "sourceInfo" in d:
+                            spdx_package.set_sourceinfo(d["sourceInfo"])
                         if "licenseConcluded" in d:
                             spdx_package.set_licenseconcluded(d["licenseConcluded"])
                         if "licenseDeclared" in d:


### PR DESCRIPTION
The key of Source information field in SPDX 2.3 should be sourceInfo instead of sourceinfo

Source: https://spdx.github.io/spdx-spec/v2.3/package-information/#712-source-information-field