### PR TITLE
Typos: filesAnaylzed -> filesAnalyzed

### DIFF
--- a/lib4sbom/spdx/spdx_parser.py
+++ b/lib4sbom/spdx/spdx_parser.py
@@ -386,9 +386,9 @@ class SPDXParser:
                                 originator_type, originator_name
                             )
                         if "filesAnalyzed" in d:
-                            spdx_package.set_filesAnalyzed(d["filesAnalyzed"])
+                            spdx_package.set_filesanalysis(d["filesAnalyzed"])
                         if "filename" in d:
-                            spdx_package.set_fileName(d["filename"])
+                            spdx_package.set_filename(d["filename"])
                         if "homepage" in d:
                             spdx_package.set_homepage(d["homepage"])
                         if "primaryPackagePurpose" in d:

--- a/lib4sbom/spdx/spdx_parser.py
+++ b/lib4sbom/spdx/spdx_parser.py
@@ -385,8 +385,8 @@ class SPDXParser:
                             spdx_package.set_originator(
                                 originator_type, originator_name
                             )
-                        if "filesAnaylzed" in d:
-                            spdx_package.set_filesAnalyzed(d["filesAnaylzed"])
+                        if "filesAnalyzed" in d:
+                            spdx_package.set_filesAnalyzed(d["filesAnalyzed"])
                         if "filename" in d:
                             spdx_package.set_fileName(d["filename"])
                         if "homepage" in d:


### PR DESCRIPTION
There are typos in the JSON SPDX parser, and they force all 'filesAnalyzed' to false when reading an SBOM.