### PR TITLE
Fix typo preventing generating correct copyright

### DIFF
--- a/lib4sbom/spdx/spdx_generator.py
+++ b/lib4sbom/spdx/spdx_generator.py
@@ -402,7 +402,7 @@ class SPDXGenerator:
                         component["licenseInfoInFiles"].append(self.license_ident(info))
                     else:
                         component["licenseInfoInFiles"] = [self.license_ident(info)]
-        component["copyrightText"] = package_info.get("copyrightText", "NOASSERTION")
+        component["copyrightText"] = package_info.get("copyrighttext", "NOASSERTION")
         if "description" in package_info:
             component["description"] = package_info["description"]
         if "comment" in package_info:


### PR DESCRIPTION
The SPDX generator had a typo that prevented it from correctly generating the copyright text.
An example is at https://github.com/anthonyharrison/sbommerge/issues/5.