### PR TITLE
feat: Multiple licenses from CycloneDX files preserved by parser

### DIFF
--- a/lib4sbom/cyclonedx/cyclonedx_parser.py
+++ b/lib4sbom/cyclonedx/cyclonedx_parser.py
@@ -245,9 +245,11 @@ class CycloneDXParser:
                         checksum["alg"].replace("SHA-", "SHA"), checksum["content"]
                     )
             license_data = None
+            multi_license_data = None
             # Multiple ways of defining license data
             if "licenses" in d and len(d["licenses"]) > 0:
                 license_data = d["licenses"][0]
+                multi_license_data = d["licenses"]
             elif "evidence" in d:
                 if "licenses" in d["evidence"]:
                     if len(d["evidence"]["licenses"]) > 0:
@@ -268,6 +270,8 @@ class CycloneDXParser:
                     # Assume License concluded is same as license declared
                     self.cyclonedx_package.set_licenseconcluded(license)
                     self.cyclonedx_package.set_licensedeclared(license)
+            if multi_license_data is not None:
+                self.cyclonedx_package.set_licenselist(multi_license_data)
             if "copyright" in d:
                 self.cyclonedx_package.set_copyrighttext(d["copyright"])
             if "cpe" in d:

--- a/lib4sbom/data/package.py
+++ b/lib4sbom/data/package.py
@@ -136,6 +136,9 @@ class SBOMPackage:
             # Use name if not SPDX license. license is then assumed to be the license text
             self.package["licensename"] = name
 
+    def set_licenselist(self, list):
+        self.package["licenselist"] = list
+
     def set_licensecomments(self, comment):
         self.package["licensecomments"] = self._text(comment)
 

--- a/test/data/testapp2.json
+++ b/test/data/testapp2.json
@@ -69,6 +69,27 @@
       },
       "cpe": "cpe:/a:Unknown:platformdirs:2.5.4",
       "purl": "pkg:pypi/platformdirs@2.5.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "5-multi-license",
+      "name": "multi-license",
+      "version": "20.16.7",
+      "author": "Bernat_Gabor",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        },
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/multi-license@20.16.7"
     }
   ],
   "dependencies": [

--- a/test/test_cyclonedx_parser.py
+++ b/test/test_cyclonedx_parser.py
@@ -1,9 +1,15 @@
+import os
 import pytest
 
 from lib4sbom.cyclonedx.cyclonedx_parser import CycloneDXParser as test_module
 
 
 class TestCcycloneDX_parser:
+    def get_test_filepath(self, relpath):
+        file_path = os.path.abspath(os.path.realpath(__file__))
+        test_data_path = os.path.join(os.path.dirname(file_path), "data")
+        return os.path.join(test_data_path, relpath)
+
     def test_parse(self):
         assert False
 
@@ -12,3 +18,21 @@ class TestCcycloneDX_parser:
 
     def test_parse_cyclonedx_xml(self):
         assert False
+
+    def test_parse_cyclonedx_multiple_licenses_json(self):
+        test_parser = test_module()
+        result = test_parser.parse(self.get_test_filepath("testapp2.json"))
+
+        cyclonedx_document, files, packages, relationships, vulnerabilities, services = result
+        multi_license = None
+        for (p, v) in packages:
+            if p == "multi-license":
+                multi_license = packages[(p, v)]
+                break
+
+        assert multi_license is not None, "Did not find expected package multi-license"
+        assert "licenselist" in multi_license
+        license_list = multi_license["licenselist"]
+        assert len(license_list) == 2
+        assert license_list[0]["license"]["id"] == "MIT"
+        assert license_list[1]["license"]["id"] == "Apache-2.0"


### PR DESCRIPTION
Many packages are subject to multiple licenses, e.g. Debian OS packages, and 
other long-lived packages.
To analyse the license situation this information is important. Just using the first license in 
the list often yields quite wrong results, such as only showing a documentation license
instead of a GPL license.