### PR TITLE
fix: cyclonedx handling of user defined component id

### DIFF
--- a/lib4sbom/generator.py
+++ b/lib4sbom/generator.py
@@ -361,7 +361,7 @@ class SBOMGenerator:
                     my_id = package.get("id", None)
                     if not self._validate_id(my_id):
                         my_id = f"{id}-{product}"
-                self._save_element(product, str(id) + "-" + product, my_id)
+                self._save_element(product, my_id, my_id)
                 if parent == "-":
                     type = "application"
                 else:


### PR DESCRIPTION
In cyclondx generator, replace `self._save_element(product, str(id) + "-" + product, my_id)` by `self._save_element(product, my_id, my_id)` as already done in spdx generator since commit 6b007bf564aa95de2854bcf328f3005382261638

Otherwise, if the user provides an id through the `set_id` function, it will not be taken into account