### PR TITLE
cyclonedx_generator: fix distributionConstraints

### DIFF
--- a/lib4sbom/cyclonedx/cyclonedx_generator.py
+++ b/lib4sbom/cyclonedx/cyclonedx_generator.py
@@ -210,9 +210,10 @@ class CycloneDXGenerator:
                 metadata_property.append(property_entry)
             metadata["properties"] = metadata_property
         metadata["component"] = component
-        distributionConstraints = dict()
-        distributionConstraints["tlp"] = component_type["distribution"]
-        metadata["distributionConstraints"] = distributionConstraints
+        if component_type["distribution"] is not None:
+            distributionConstraints = dict()
+            distributionConstraints["tlp"] = component_type["distribution"]
+            metadata["distributionConstraints"] = distributionConstraints
         self.doc["metadata"] = metadata
         return component["bom-ref"]
 


### PR DESCRIPTION
Since version 0.9.0 and addition of CycloneDX 1.7, a null statement is added to SBOM if `component_type` has no distribution set:

```
    "distributionConstraints": {
      "tlp": null
    }
```

Fix 78143adef792ad792ccd5cf3cdd207b4a87543ab