### PR TITLE
fix: SPDX handling of OPERATING-SYSTEM for JSON (fixes #78)

### DIFF
--- a/lib4sbom/spdx/spdx_generator.py
+++ b/lib4sbom/spdx/spdx_generator.py
@@ -453,8 +453,9 @@ class SPDXGenerator:
         elif self.debug:
             print(f"[WARNING] **** version missing for {package}")
         if "type" in package_info:
+            # Handle SPDX mismatch of - and _ in OPERATING-SYSTEM
             component["primaryPackagePurpose"] = (
-                package_info["type"].upper().replace("-", "_")
+                package_info["type"].upper().replace("_", "-")
             )
         else:
             component["primaryPackagePurpose"] = "LIBRARY"


### PR DESCRIPTION
The same issue was already addressed for tag serialization in [commit 808b80a](https://github.com/anthonyharrison/lib4sbom/commit/808b80a16db942ece6807ebbf26e7763ad4e4c35). This matches the JSON serialization.