### PR TITLE
fix: cyclonedx's vulnerabilities[].affects[].versions must be an array

### DIFF
--- a/lib4sbom/cyclonedx/cyclonedx_generator.py
+++ b/lib4sbom/cyclonedx/cyclonedx_generator.py
@@ -865,7 +865,7 @@ class CycloneDXGenerator:
                     version_info["version"] = component_version
                     version_info["status"] = "affected"
                 if len(version_info) > 0:
-                    affected["versions"] = version_info
+                    affected["versions"] = [version_info]
                 affects.append(affected)
                 vulnerability["affects"] = affects
             # Add properties for any user defined items


### PR DESCRIPTION
Currently, we generate an invalid CycloneDX SBOM because we set vulnerabilities[].affects[].versions as an object instead of an array of objects as required[1].

Let's fix that oversight.

[1] https://cyclonedx.org/docs/1.7/json/#vulnerabilities_items_affects_items_versions

This was tested with cve-bin-tool VEX file generation and checked with check-jsonschema against https://github.com/CycloneDX/specification/blob/1.6.1/schema/bom-1.6.schema.json